### PR TITLE
tutorial: hello world: fix c code markdown render error

### DIFF
--- a/markdown/tutorials/basic/hello-world.md
+++ b/markdown/tutorials/basic/hello-world.md
@@ -145,7 +145,6 @@ to the PLAYING state.
 
 In this line, `gst_element_set_state()` is setting `pipeline` (our only
 element, remember) to the PLAYING state, thus initiating playback.
-```
 
 ``` c
     /* Wait until error or EOS */


### PR DESCRIPTION
Fix a minor markdown render error in the docs.