### PR TITLE
Fedora install uses incorrect names for ugly plugins

### DIFF
--- a/markdown/installing/on-linux.md
+++ b/markdown/installing/on-linux.md
@@ -15,7 +15,7 @@ Make sure you have superuser (root) access rights to install GStreamer.
 Run the following command:
 
 ```
-dnf install gstreamer1-devel gstreamer1-plugins-base-tools gstreamer1-devel-docs gstreamer1-plugins-base-devel gstreamer1-plugins-base-devel-docs gstreamer1-plugins-good gstreamer1-plugins-good-extras gstreamer1-plugins-ugly gstreamer1-plugins-ugly-devel-docs  gstreamer1-plugins-bad-free gstreamer1-plugins-bad-free-devel gstreamer1-plugins-bad-free-extras
+dnf install gstreamer1-devel gstreamer1-plugins-base-tools gstreamer1-devel-docs gstreamer1-plugins-base-devel gstreamer1-plugins-base-devel-docs gstreamer1-plugins-good gstreamer1-plugins-good-extras gstreamer1-plugins-ugly-free gstreamer1-plugins-ugly-free-devel  gstreamer1-plugins-bad-free gstreamer1-plugins-bad-free-devel gstreamer1-plugins-bad-free-extras
 ```
 
 ## Install GStreamer on Ubuntu or Debian


### PR DESCRIPTION
When running the install command from the documentation on Fedora 30, it installs but the output gets to a point where it tells you that the gstreamer1-plugins-ugly is not found.

```sh
$ sudo dnf install gstreamer1-devel gstreamer1-plugins-base-tools gstreamer1-devel-docs gstreamer1-plugins-base-devel gstreamer1-plugins-base-devel-docs gstreamer1-plugins-good gstreamer1-plugins-good-extras gstreamer1-plugins-ugly gstreamer1-plugins-ugly-devel-docs  gstreamer1-plugins-bad-free gstreamer1-plugins-bad-free-devel gstreamer1-plugins-bad-free-extras

No match for argument: gstreamer1-plugins-ugly
No match for argument: gstreamer1-plugins-ugly-devel-docs
```
If we do a dnf search for gstreamer and ugly, we get

```sh
$ sudo dnf search gstreamer1 ugly
Last metadata expiration check: 0:00:25 ago on Fri 04 Oct 2019 02:20:08 PM CDT.
=================== Name & Summary Matched: ugly, gstreamer1 ===================
gstreamer1-plugins-ugly-free.i686 : GStreamer streaming media framework "ugly"
                                  : plugins
gstreamer1-plugins-ugly-free.x86_64 : GStreamer streaming media framework "ugly"
                                    : plugins
gstreamer1-plugins-ugly-free-devel.i686 : Development files for the GStreamer
                                        : media framework "ugly" plug-ins
gstreamer1-plugins-ugly-free-devel.x86_64 : Development files for the GStreamer
                                          : media framework "ugly" plug-ins
```
Therefore, this request is to change them to the new names.